### PR TITLE
return err in read_compressed instead of panicking

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -465,7 +465,7 @@ fn read_compressed(r: &mut impl Read) -> io::Result<impl Read> {
         r.read_exact(&mut compressed)?;
         let mut decoder = zlib::Decoder::new(&compressed[..])?;
         let mut uncompressed = vec![0; uncompressed_size as usize];
-        decoder.read_exact(&mut uncompressed).unwrap();
+        decoder.read_exact(&mut uncompressed)?;
         Ok(Cursor::new(uncompressed))
     }
 }


### PR DESCRIPTION
Attempting to address https://github.com/brickadia/brs/issues/4

At first I attempted to reconstruct a panicking input, but it was a lot of trouble so I just ended up returning the Err instead of unwrapping. The panic would only have happened if the actual uncompressed size does not match the indicated uncompressed size. I'm unfamiliar with zlib and brs so if it is more complicated than this please let me know.